### PR TITLE
Update to ESM and add type declarations

### DIFF
--- a/color-json.d.ts
+++ b/color-json.d.ts
@@ -1,0 +1,34 @@
+export type ColorMap = {
+    black: string,
+    red: string,
+    red: string,
+    yellow: string,
+    blue: string,
+    magenta: string,
+    cyan: string,
+    white: string
+};
+
+export type Colors = {
+    separator: keyof ColorMap,
+    string: keyof ColorMap,
+    number: keyof ColorMap,
+    boolean: keyof ColorMap,
+    null: keyof ColorMap,
+    key: keyof ColorMap,
+}
+
+/**
+ * Given an object, it returns its JSON representation colored using
+ * ANSI escape characters.
+ * @param json {any} JSON object to highlighter
+ * @param colors {Colors} An map with the ANSI characters for each supported color.
+ * @param colorMap {Colors} An object to configure the coloring.
+ * @param spacing {number} The indentation spaces.
+ */
+export default function colorJson(
+    json: any,
+    colors: Colors,
+    colorMap: ColorMap,
+    spacing: number
+): string

--- a/color-json.d.ts
+++ b/color-json.d.ts
@@ -1,34 +1,34 @@
 export type ColorMap = {
-    black: string,
-    red: string,
-    red: string,
-    yellow: string,
-    blue: string,
-    magenta: string,
-    cyan: string,
-    white: string
+  black: string,
+  red: string,
+  yellow: string,
+  blue: string,
+  magenta: string,
+  cyan: string,
+  white: string
 };
 
 export type Colors = {
-    separator: keyof ColorMap,
-    string: keyof ColorMap,
-    number: keyof ColorMap,
-    boolean: keyof ColorMap,
-    null: keyof ColorMap,
-    key: keyof ColorMap,
+  separator: keyof ColorMap,
+  string: keyof ColorMap,
+  number: keyof ColorMap,
+  boolean: keyof ColorMap,
+  null: keyof ColorMap,
+  key: keyof ColorMap,
 }
 
 /**
  * Given an object, it returns its JSON representation colored using
  * ANSI escape characters.
- * @param json {any} JSON object to highlighter
- * @param colors {Colors} An map with the ANSI characters for each supported color.
- * @param colorMap {Colors} An object to configure the coloring.
- * @param spacing {number} The indentation spaces.
+ * @param {(Object | string)} json - JSON object to highlighter.
+ * @param {Colors} [colors] - A map with the ANSI characters for each supported color.
+ * @param {ColorMap} [colorMap] - An object to configure the coloring.
+ * @param {number} [spacing=2] - The indentation spaces.
+ * @returns {string} Stringified JSON colored with ANSI escape characters.
  */
 export default function colorJson(
-    json: any,
-    colors: Colors,
-    colorMap: ColorMap,
-    spacing: number
+  json: Object | string,
+  colors?: Colors,
+  colorMap?: ColorMap,
+  spacing?: number
 ): string

--- a/color-json.js
+++ b/color-json.js
@@ -1,6 +1,6 @@
-const supportsColor = require('./lib/supportsColor');
+import { supportsColor } from './lib/supportsColor.js';
 
-const defaultColorMap = {
+export const defaultColorMap = {
   black: '\x1b[30m',
   red: '\x1b[31m',
   green: '\x1b[32m',
@@ -11,7 +11,7 @@ const defaultColorMap = {
   white: '\x1b[37m'
 };
 
-const defaultColors = {
+export const defaultColors = {
   separator: 'yellow',
   string: 'green',
   number: 'magenta',
@@ -20,21 +20,23 @@ const defaultColors = {
   key: 'white'
 };
 
-module.exports = supportsColor() ? function syntaxHighlight(json, colors = defaultColors, colorMap = defaultColorMap, spacing = 2) { // thanks: https://stackoverflow.com/a/7220510/4151489
-  if (typeof json != 'string') json = JSON.stringify(json, undefined, spacing);
-  else json = JSON.stringify(JSON.parse(json), undefined, spacing);
-  return colorMap[colors.separator] + json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function (match) {
-    let colorCode = 'number';
-    if (/^"/.test(match)) {
-      if (/:$/.test(match)) colorCode = 'key';
-      else colorCode = 'string';
-    } else if (/true|false/.test(match)) colorCode = 'boolean';
-    else if (/null/.test(match)) colorCode = 'null';
-    const color = colorMap[colors[colorCode]] || '';
-    return `\x1b[0m${color}${match}${colorMap[colors.separator]}`;
-  }) + '\x1b[0m';
-} : function syntaxNoHighlight(json, colors = defaultColors, colorMap = defaultColorMap, spacing = 2) {
-  if (typeof json != 'string') json = JSON.stringify(json, undefined, spacing);
-  else json = JSON.stringify(JSON.parse(json), undefined, spacing);
-  return json;
-};
+export default function colorJson(json, colors = defaultColors, colorMap = defaultColorMap, spacing = 2) {
+  if (supportsColor()) {
+    if (typeof json != 'string') json = JSON.stringify(json, undefined, spacing);
+    else json = JSON.stringify(JSON.parse(json), undefined, spacing);
+    return colorMap[colors.separator] + json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function (match) {
+      let colorCode = 'number';
+      if (/^"/.test(match)) {
+        if (/:$/.test(match)) colorCode = 'key';
+        else colorCode = 'string';
+      } else if (/true|false/.test(match)) colorCode = 'boolean';
+      else if (/null/.test(match)) colorCode = 'null';
+      const color = colorMap[colors[colorCode]] || '';
+      return `\x1b[0m${color}${match}${colorMap[colors.separator]}`;
+    }) + '\x1b[0m';
+  } else {
+    if (typeof json != 'string') json = JSON.stringify(json, undefined, spacing);
+    else json = JSON.stringify(JSON.parse(json), undefined, spacing);
+    return json;
+  }
+}

--- a/lib/supportsColor.js
+++ b/lib/supportsColor.js
@@ -1,5 +1,5 @@
 // TODO: this is super beta, consider using Sindre's supports-colors
-module.exports = function supportsColor() {
+export function supportsColor() {
   const onHeroku = truth(process.env.DYNO) ? true : false;
   const forceNoColor = truth(process.env.FORCE_NO_COLOR) ? true : false;
   const forceColor = truth(process.env.FORCE_COLOR) ? true : false;

--- a/package.json
+++ b/package.json
@@ -2,9 +2,15 @@
   "name": "color-json",
   "version": "2.0.1",
   "description": "Color JSON in the console with no dependencies",
-  "main": "color-json.js",
+  "type": "module",
   "directories": {
     "test": "tests"
+  },
+  "exports": {
+    ".": {
+      "import": "./color-json.js",
+      "types": "./color-json.d.ts"
+    }
   },
   "scripts": {
     "test": "node tests/test.js; TMP_FORCE_NO_COLOR=$FORCE_NO_COLOR; export FORCE_NO_COLOR=true; echo '=====================\nTesting without color\n====================='; node tests/test.js; export FORCE_NO_COLOR=$TMP_FORCE_NO_COLOR; unset TMP_FORCE_NO_COLOR"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color-json",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Color JSON in the console with no dependencies",
   "type": "module",
   "directories": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,4 +1,4 @@
-const colorJson = require('../color-json.js');
+import colorJson from '../color-json.js';
 
 console.log('default usage:');
 const topPlanets = [


### PR DESCRIPTION
Thanks a lot @zvakanaka for building this utility. We use it from the [Shopify CLI](https://github.com/Shopify/cli/blob/main/packages/cli-kit/package.json#L97) to color the JSON objects that we output to the user. We are in the process of moving all our dependencies to their ESM version, and I just noticed that `color-json` remains CJS. Therefore, I've opened this PR to migrate it to be pure ESM.

Please, let me know if the breaking change sounds sensible to you. I chose this path to help with the widespread of ESM and prevent having to introduce additional tooling in the repository. If it sounds good to you, would it be possible to do a major release afterward?

Thanks a lot in advance.